### PR TITLE
Add support for OIDC token auth with AWS STS role

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following configuration options are available:
    * Importance: low
 
 ``large.message.s3.jwt.path``
-   Path to an OIDC token file in JSON format (JWT) used to authenticate before AWS STS role authorisation, ex. for EKS `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.
+   Path to an OIDC token file in JSON format (JWT) used to authenticate before AWS STS role authorisation, e.g. for EKS `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.
 
    * Type: string
    * Default: ""

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ The following configuration options are available:
    * Default: ""
    * Importance: low
 
+``large.message.s3.jwt.path``
+   Path to an OIDC token file in JSON format (JWT) used to authenticate before AWS STS role authorisation, ex. for EKS `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.
+
+   * Type: string
+   * Default: ""
+   * Importance: low
+
 ``large.message.s3.region``
   S3 region to use. Must be configured in conjunction with s3backed.endpoint. Leave empty if default S3 region should be used.
 

--- a/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
@@ -270,7 +270,7 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
         final String jwtPath = this.getString(S3_JWT_PATH_CONFIG);
 
         if (!isEmpty(roleArn) && !isEmpty(roleSessionName)) {
-            final AWSCredentialsProvider provider;
+            AWSCredentialsProvider provider = null;
 
             if (!isEmpty(roleExternalId)) {
                 provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
@@ -280,7 +280,7 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
             }
 
             if (!isEmpty(jwtPath)) {
-                provider = new WebIdentityTokenCredentialsProvider.Builder()
+                provider = WebIdentityTokenCredentialsProvider.builder()
                                 .webIdentityTokenFile(jwtPath)
                                 .roleArn(roleArn)
                                 .roleSessionName(roleSessionName)

--- a/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
@@ -270,24 +270,27 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
         final String jwtPath = this.getString(S3_JWT_PATH_CONFIG);
 
         if (!isEmpty(roleArn) && !isEmpty(roleSessionName)) {
-            AWSCredentialsProvider provider = null;
 
             if (!isEmpty(roleExternalId)) {
-                provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+                final AWSCredentialsProvider roleProvider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
                                 .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
                                 .withExternalId(roleExternalId)
                                 .build();
+
+                return Optional.of(roleProvider);
             }
 
             if (!isEmpty(jwtPath)) {
-                provider = WebIdentityTokenCredentialsProvider.builder()
+                final AWSCredentialsProvider oidcProvider = WebIdentityTokenCredentialsProvider.builder()
                                 .webIdentityTokenFile(jwtPath)
                                 .roleArn(roleArn)
                                 .roleSessionName(roleSessionName)
                                 .build();
+
+                return Optional.of(oidcProvider);
             }
 
-            return Optional.of(provider);
+
         }
 
         return Optional.empty();


### PR DESCRIPTION
**Which problem this PR is trying to solve**
I am using the Serde with Kafka Connect, AWS S3 and STS [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). It works properly, however I now have the requirement to move to [AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).

**What is the suggested solution**
Extend AbstractLargeMessageConfig with new configuration parameter S3_JWT_PATH_CONFIG and provider of kind WebIdentityTokenCredentialsProvider.

**Additional information**
Related [issue](https://github.com/bakdata/kafka-large-message-serde/issues/20) was raised on main project.