### PR TITLE
Use no headers when not passed explicitly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ resources:
   repositories:
     - repository: templates
       type: github
+      ref: tmp/upload-snapshot
       name: bakdata/bakdata-project-templates
       endpoint: bot
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ resources:
   repositories:
     - repository: templates
       type: github
-      ref: tmp/upload-snapshot
       name: bakdata/bakdata-project-templates
       endpoint: bot
 

--- a/large-message-connect/src/main/java/com/bakdata/kafka/LargeMessageConverter.java
+++ b/large-message-connect/src/main/java/com/bakdata/kafka/LargeMessageConverter.java
@@ -51,11 +51,6 @@ public class LargeMessageConverter implements Converter {
         this.converter.configure(configs, isKey);
     }
 
-    /**
-     * @since 2.2.0
-     * @deprecated Use {@link #fromConnectData(String, Headers, Schema, Object)}
-     */
-    @Deprecated
     @Override
     public byte[] fromConnectData(final String topic, final Schema schema, final Object value) {
         final byte[] inner = this.converter.fromConnectData(topic, schema, value);
@@ -68,11 +63,6 @@ public class LargeMessageConverter implements Converter {
         return this.storingClient.storeBytes(topic, inner, this.isKey, headers);
     }
 
-    /**
-     * @since 2.2.0
-     * @deprecated Use {@link #toConnectData(String, Headers, byte[])}
-     */
-    @Deprecated
     @Override
     public SchemaAndValue toConnectData(final String topic, final byte[] value) {
         final byte[] inner = this.retrievingClient.retrieveBytes(value, this.isKey);

--- a/large-message-core/src/main/java/com/bakdata/kafka/ByteFlagLargeMessagePayloadProtocol.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/ByteFlagLargeMessagePayloadProtocol.java
@@ -27,8 +27,6 @@ package com.bakdata.kafka;
 import static com.bakdata.kafka.FlagHelper.asFlag;
 import static com.bakdata.kafka.FlagHelper.isBacked;
 
-import org.apache.kafka.common.header.Headers;
-
 final class ByteFlagLargeMessagePayloadProtocol implements LargeMessagePayloadProtocol {
 
     static byte[] stripFlag(final byte[] data) {
@@ -39,7 +37,7 @@ final class ByteFlagLargeMessagePayloadProtocol implements LargeMessagePayloadPr
     }
 
     @Override
-    public byte[] serialize(final LargeMessagePayload payload, final Headers headers, final boolean isKey) {
+    public byte[] serialize(final LargeMessagePayload payload, final boolean isKey) {
         final byte[] bytes = payload.getData();
         final byte[] fullBytes = new byte[bytes.length + 1];
         fullBytes[0] = asFlag(payload.isBacked());
@@ -48,7 +46,7 @@ final class ByteFlagLargeMessagePayloadProtocol implements LargeMessagePayloadPr
     }
 
     @Override
-    public LargeMessagePayload deserialize(final byte[] data, final Headers headers, final boolean isKey) {
+    public LargeMessagePayload deserialize(final byte[] data, final boolean isKey) {
         return new LargeMessagePayload(isBacked(data[0]), stripFlag(data));
     }
 }

--- a/large-message-core/src/main/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocol.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocol.java
@@ -28,6 +28,7 @@ import static com.bakdata.kafka.AbstractLargeMessageConfig.PREFIX;
 import static com.bakdata.kafka.FlagHelper.asFlag;
 import static com.bakdata.kafka.FlagHelper.isBacked;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
@@ -59,7 +60,7 @@ final class HeaderLargeMessagePayloadProtocol implements LargeMessagePayloadProt
 
     @Override
     public byte[] serialize(final LargeMessagePayload payload, final boolean isKey) {
-        throw new UnsupportedOperationException("Cannot serialize without headers");
+        throw new SerializationException("Cannot serialize without headers");
     }
 
     @Override
@@ -71,6 +72,6 @@ final class HeaderLargeMessagePayloadProtocol implements LargeMessagePayloadProt
 
     @Override
     public LargeMessagePayload deserialize(final byte[] bytes, final boolean isKey) {
-        throw new UnsupportedOperationException("Cannot deserialize without headers");
+        throw new SerializationException("Cannot deserialize without headers");
     }
 }

--- a/large-message-core/src/main/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocol.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocol.java
@@ -58,9 +58,19 @@ final class HeaderLargeMessagePayloadProtocol implements LargeMessagePayloadProt
     }
 
     @Override
+    public byte[] serialize(final LargeMessagePayload payload, final boolean isKey) {
+        throw new UnsupportedOperationException("Cannot serialize without headers");
+    }
+
+    @Override
     public LargeMessagePayload deserialize(final byte[] bytes, final Headers headers, final boolean isKey) {
         final Header header = headers.lastHeader(getHeaderName(isKey));
         final byte flag = header.value()[0];
         return new LargeMessagePayload(isBacked(flag), bytes);
+    }
+
+    @Override
+    public LargeMessagePayload deserialize(final byte[] bytes, final boolean isKey) {
+        throw new UnsupportedOperationException("Cannot deserialize without headers");
     }
 }

--- a/large-message-core/src/main/java/com/bakdata/kafka/LargeMessagePayloadProtocol.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/LargeMessagePayloadProtocol.java
@@ -39,7 +39,18 @@ public interface LargeMessagePayloadProtocol {
      * @param isKey whether payload represents a key or value
      * @return bytes representing serialized payload
      */
-    byte[] serialize(LargeMessagePayload payload, Headers headers, boolean isKey);
+    default byte[] serialize(final LargeMessagePayload payload, final Headers headers, final boolean isKey) {
+        return this.serialize(payload, isKey);
+    }
+
+    /**
+     * Serialize a large message payload to bytes.
+     *
+     * @param payload large message payload
+     * @param isKey whether payload represents a key or value
+     * @return bytes representing serialized payload
+     */
+    byte[] serialize(LargeMessagePayload payload, boolean isKey);
 
     /**
      * Deserialize a large message payload from bytes and headers. Headers might be modified to remove deserialization
@@ -50,5 +61,16 @@ public interface LargeMessagePayloadProtocol {
      * @param isKey whether payload represents a key or value
      * @return deserialized payload
      */
-    LargeMessagePayload deserialize(byte[] bytes, Headers headers, boolean isKey);
+    default LargeMessagePayload deserialize(final byte[] bytes, final Headers headers, final boolean isKey) {
+        return this.deserialize(bytes, isKey);
+    }
+
+    /**
+     * Deserialize a large message payload from bytes and headers.
+     *
+     * @param bytes serialized large message payload
+     * @param isKey whether payload represents a key or value
+     * @return deserialized payload
+     */
+    LargeMessagePayload deserialize(byte[] bytes, boolean isKey);
 }

--- a/large-message-core/src/main/java/com/bakdata/kafka/LargeMessageRetrievingClient.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/LargeMessageRetrievingClient.java
@@ -71,6 +71,25 @@ public class LargeMessageRetrievingClient {
         }
         final LargeMessagePayloadProtocol protocol = getProtocol(headers, isKey);
         final LargeMessagePayload payload = protocol.deserialize(data, headers, isKey);
+        return this.getBytes(payload);
+    }
+
+    /**
+     * Retrieve a payload that may have been stored on blob storage
+     *
+     * @param data payload
+     * @param isKey whether the payload represents the key of a message
+     * @return actual payload retrieved from blob storage
+     */
+    public byte[] retrieveBytes(final byte[] data, final boolean isKey) {
+        if (data == null) {
+            return null;
+        }
+        final LargeMessagePayload payload = BYTE_FLAG_PROTOCOL.deserialize(data, isKey);
+        return this.getBytes(payload);
+    }
+
+    private byte[] getBytes(final LargeMessagePayload payload) {
         final byte[] deserializedData = payload.getData();
         if (payload.isBacked()) {
             return this.retrieveBackedBytes(deserializedData);

--- a/large-message-core/src/main/java/com/bakdata/kafka/LargeMessageStoringClient.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/LargeMessageStoringClient.java
@@ -46,18 +46,8 @@ public class LargeMessageStoringClient {
     private final IdGenerator idGenerator;
     private final @NonNull LargeMessagePayloadProtocol protocol;
 
-    private static byte[] serialize(final LargeMessagePayloadProtocol protocol, final String uri,
-            final Headers headers, final boolean isKey) {
-        return protocol.serialize(LargeMessagePayload.ofUri(uri), headers, isKey);
-    }
-
     private static byte[] serialize(final String uri, final boolean isKey) {
         return BYTE_FLAG_PROTOCOL.serialize(LargeMessagePayload.ofUri(uri), isKey);
-    }
-
-    private static byte[] serialize(final LargeMessagePayloadProtocol protocol, final byte[] bytes,
-            final Headers headers, final boolean isKey) {
-        return protocol.serialize(LargeMessagePayload.ofBytes(bytes), headers, isKey);
     }
 
     private static byte[] serialize(final byte[] bytes, final boolean isKey) {
@@ -83,9 +73,9 @@ public class LargeMessageStoringClient {
         }
         if (this.needsBacking(bytes)) {
             final String uri = this.uploadToBlobStorage(topic, bytes, isKey);
-            return serialize(this.protocol, uri, headers, isKey);
+            return this.serialize(uri, headers, isKey);
         } else {
-            return serialize(this.protocol, bytes, headers, isKey);
+            return this.serialize(bytes, headers, isKey);
         }
     }
 
@@ -121,6 +111,14 @@ public class LargeMessageStoringClient {
         log.info("Deleting blob storage backed files for topic '{}'", topic);
         this.client.deleteAllObjects(bucketName, prefix);
         log.info("Finished deleting blob storage backed files for topic '{}'", topic);
+    }
+
+    private byte[] serialize(final String uri, final Headers headers, final boolean isKey) {
+        return this.protocol.serialize(LargeMessagePayload.ofUri(uri), headers, isKey);
+    }
+
+    private byte[] serialize(final byte[] bytes, final Headers headers, final boolean isKey) {
+        return this.protocol.serialize(LargeMessagePayload.ofBytes(bytes), headers, isKey);
     }
 
     private String uploadToBlobStorage(final String topic, final byte[] bytes, final boolean isKey) {

--- a/large-message-core/src/test/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocolTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/HeaderLargeMessagePayloadProtocolTest.java
@@ -148,6 +148,20 @@ class HeaderLargeMessagePayloadProtocolTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    void shouldThrowExceptionWhenCalledWithoutHeaders(final boolean isKey) {
+        final byte[] payload = {2};
+        this.softly.assertThatThrownBy(() -> new HeaderLargeMessagePayloadProtocol().deserialize(payload, isKey))
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Cannot deserialize without headers");
+        this.softly.assertThatThrownBy(
+                        () -> new HeaderLargeMessagePayloadProtocol().serialize(new LargeMessagePayload(true,
+                                payload), isKey))
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Cannot serialize without headers");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     void shouldDetectHeaders(final boolean isKey) {
         this.softly.assertThat(usesHeaders(new RecordHeaders()
                         .add(getHeaderName(isKey), new byte[]{1}), isKey))

--- a/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
@@ -80,7 +80,7 @@ class LargeMessageRetrievingClientTest {
         assertThat(headers.headers(getHeaderName(isKey))).hasSize(1);
     }
 
-    private static byte[] serialize(final byte[] bytes) {
+    static byte[] serialize(final byte[] bytes) {
         return BYTE_FLAG_PROTOCOL.serialize(ofBytes(bytes), new RecordHeaders(), false);
     }
 

--- a/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
@@ -76,12 +76,12 @@ class LargeMessageRetrievingClientTest {
         return BYTE_FLAG_PROTOCOL.serialize(ofUri(uri), new RecordHeaders(), false);
     }
 
-    private static void assertHasHeader(final Headers headers, final boolean isKey) {
-        assertThat(headers.headers(getHeaderName(isKey))).hasSize(1);
-    }
-
     static byte[] serialize(final byte[] bytes) {
         return BYTE_FLAG_PROTOCOL.serialize(ofBytes(bytes), new RecordHeaders(), false);
+    }
+
+    private static void assertHasHeader(final Headers headers, final boolean isKey) {
+        assertThat(headers.headers(getHeaderName(isKey))).hasSize(1);
     }
 
     private static byte[] createNonBackedText(final String text) {

--- a/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageRetrievingClientTest.java
@@ -125,6 +125,14 @@ class LargeMessageRetrievingClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    void shouldReadNonBackedTextWithoutHeaders(final boolean isKey) {
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        assertThat(retriever.retrieveBytes(createNonBackedText("foo"), isKey))
+                .isEqualTo(serialize("foo"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     void shouldReadNonBackedTextWithHeaders(final boolean isKey) {
         final LargeMessageRetrievingClient retriever = this.createRetriever();
         final Headers headers = nonBackedHeaders(isKey);
@@ -143,12 +151,31 @@ class LargeMessageRetrievingClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    void shouldReadNullWithoutHeaders(final boolean isKey) {
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        assertThat(retriever.retrieveBytes(null, isKey))
+                .isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     void shouldReadBackedText(final boolean isKey) {
         final String bucket = "bucket";
         final String key = "key";
         when(this.client.getObject(bucket, key)).thenReturn(serialize("foo"));
         final LargeMessageRetrievingClient retriever = this.createRetriever();
         assertThat(retriever.retrieveBytes(createBackedText(bucket, key), new RecordHeaders(), isKey))
+                .isEqualTo(serialize("foo"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void shouldReadBackedTextWithoutHeaders(final boolean isKey) {
+        final String bucket = "bucket";
+        final String key = "key";
+        when(this.client.getObject(bucket, key)).thenReturn(serialize("foo"));
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        assertThat(retriever.retrieveBytes(createBackedText(bucket, key), isKey))
                 .isEqualTo(serialize("foo"));
     }
 
@@ -177,6 +204,15 @@ class LargeMessageRetrievingClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    void shouldThrowExceptionOnErroneousFlagWithoutHeaders(final boolean isKey) {
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        assertThatExceptionOfType(SerializationException.class)
+                .isThrownBy(() -> retriever.retrieveBytes(new byte[]{2}, isKey))
+                .withMessage("Message can only be marked as backed or non-backed");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     void shouldThrowExceptionOnErroneousFlagWithHeaders(final boolean isKey) {
         final LargeMessageRetrievingClient retriever = this.createRetriever();
         final Headers headers = newHeaders((byte) 2, isKey);
@@ -192,6 +228,16 @@ class LargeMessageRetrievingClientTest {
         final Headers headers = new RecordHeaders();
         assertThatExceptionOfType(SerializationException.class)
                 .isThrownBy(() -> retriever.retrieveBytes(new byte[]{1, 0}, headers, isKey))
+                .withCauseInstanceOf(URISyntaxException.class)
+                .withMessage("Invalid URI");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void shouldThrowExceptionOnErroneousUriWithoutHeaders(final boolean isKey) {
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        assertThatExceptionOfType(SerializationException.class)
+                .isThrownBy(() -> retriever.retrieveBytes(new byte[]{1, 0}, isKey))
                 .withCauseInstanceOf(URISyntaxException.class)
                 .withMessage("Invalid URI");
     }
@@ -218,6 +264,18 @@ class LargeMessageRetrievingClientTest {
         final Headers headers = new RecordHeaders();
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> retriever.retrieveBytes(backedText, headers, isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void shouldThrowOnErrorWithoutHeaders(final boolean isKey) {
+        final String bucket = "bucket";
+        final String key = "key";
+        when(this.client.getObject(bucket, key)).thenThrow(UncheckedIOException.class);
+        final LargeMessageRetrievingClient retriever = this.createRetriever();
+        final byte[] backedText = createBackedText(bucket, key);
+        assertThatExceptionOfType(UncheckedIOException.class)
+                .isThrownBy(() -> retriever.retrieveBytes(backedText, isKey));
     }
 
     @ParameterizedTest

--- a/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageStoringClientTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageStoringClientTest.java
@@ -28,6 +28,7 @@ import static com.bakdata.kafka.ByteFlagLargeMessagePayloadProtocol.stripFlag;
 import static com.bakdata.kafka.FlagHelper.IS_NOT_BACKED;
 import static com.bakdata.kafka.HeaderLargeMessagePayloadProtocol.getHeaderName;
 import static com.bakdata.kafka.LargeMessagePayload.getUriBytes;
+import static com.bakdata.kafka.LargeMessageRetrievingClientTest.serializeUri;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -120,9 +121,8 @@ class LargeMessageStoringClientTest {
                 .maxSize(Integer.MAX_VALUE)
                 .build();
         final byte[] fooBytes = serialize("foo");
-        final byte[] returnBytes = {2};
-        when(this.protocol.serialize(new LargeMessagePayload(false, fooBytes), isKey)).thenReturn(returnBytes);
-        assertThat(storer.storeBytes(null, fooBytes, isKey)).isEqualTo(returnBytes);
+        assertThat(storer.storeBytes(null, fooBytes, isKey))
+                .isEqualTo(LargeMessageRetrievingClientTest.serialize(fooBytes));
     }
 
     @ParameterizedTest
@@ -177,11 +177,8 @@ class LargeMessageStoringClientTest {
                 .basePath(BlobStorageURI.create(basePath))
                 .maxSize(0)
                 .build();
-        final byte[] uriBytes = getUriBytes("uri");
-        final byte[] returnBytes = {2};
-        when(this.protocol.serialize(new LargeMessagePayload(true, uriBytes), true)).thenReturn(returnBytes);
         assertThat(storer.storeBytes(TOPIC, serialize("foo"), true))
-                .isEqualTo(returnBytes);
+                .isEqualTo(serializeUri("uri"));
     }
 
     @ParameterizedTest
@@ -236,11 +233,8 @@ class LargeMessageStoringClientTest {
                 .basePath(BlobStorageURI.create(basePath))
                 .maxSize(0)
                 .build();
-        final byte[] uriBytes = getUriBytes("uri");
-        final byte[] returnBytes = {2};
-        when(this.protocol.serialize(new LargeMessagePayload(true, uriBytes), false)).thenReturn(returnBytes);
         assertThat(storer.storeBytes(TOPIC, serialize("foo"), false))
-                .isEqualTo(returnBytes);
+                .isEqualTo(serializeUri("uri"));
     }
 
     @Test

--- a/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageStoringClientTest.java
+++ b/large-message-core/src/test/java/com/bakdata/kafka/LargeMessageStoringClientTest.java
@@ -115,6 +115,18 @@ class LargeMessageStoringClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void shouldWriteNonBackedTextWithoutHeaders(final boolean isKey) {
+        final LargeMessageStoringClient storer = this.createStorer()
+                .maxSize(Integer.MAX_VALUE)
+                .build();
+        final byte[] fooBytes = serialize("foo");
+        final byte[] returnBytes = {2};
+        when(this.protocol.serialize(new LargeMessagePayload(false, fooBytes), isKey)).thenReturn(returnBytes);
+        assertThat(storer.storeBytes(null, fooBytes, isKey)).isEqualTo(returnBytes);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void shouldWriteNonBackedNull(final boolean isKey) {
         final LargeMessageStoringClient storer = this.createStorer()
                 .maxSize(Integer.MAX_VALUE)
@@ -122,6 +134,17 @@ class LargeMessageStoringClientTest {
         assertThat(storer.storeBytes(null, null, isKey, new RecordHeaders()))
                 .isNull();
         verify(this.protocol, never()).serialize(any(), any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldWriteNonBackedNullWithoutHeaders(final boolean isKey) {
+        final LargeMessageStoringClient storer = this.createStorer()
+                .maxSize(Integer.MAX_VALUE)
+                .build();
+        assertThat(storer.storeBytes(null, null, isKey))
+                .isNull();
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
     }
 
     @Test
@@ -143,6 +166,24 @@ class LargeMessageStoringClientTest {
                 .isEqualTo(returnBytes);
     }
 
+    @Test
+    void shouldWriteBackedTextKeyWithoutHeaders() {
+        final String bucket = "bucket";
+        final String basePath = "foo://" + bucket + "/base/";
+        when(this.idGenerator.generateId(serialize("foo"))).thenReturn("key");
+        when(this.client.putObject(serialize("foo"), bucket, "base/" + TOPIC + "/keys/key"))
+                .thenReturn("uri");
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(BlobStorageURI.create(basePath))
+                .maxSize(0)
+                .build();
+        final byte[] uriBytes = getUriBytes("uri");
+        final byte[] returnBytes = {2};
+        when(this.protocol.serialize(new LargeMessagePayload(true, uriBytes), true)).thenReturn(returnBytes);
+        assertThat(storer.storeBytes(TOPIC, serialize("foo"), true))
+                .isEqualTo(returnBytes);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void shouldWriteBackedNull(final boolean isKey) {
@@ -152,6 +193,17 @@ class LargeMessageStoringClientTest {
         assertThat(storer.storeBytes(null, null, isKey, new RecordHeaders()))
                 .isNull();
         verify(this.protocol, never()).serialize(any(), any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldWriteBackedNullWithoutHeaders(final boolean isKey) {
+        final LargeMessageStoringClient storer = this.createStorer()
+                .maxSize(0)
+                .build();
+        assertThat(storer.storeBytes(null, null, isKey))
+                .isNull();
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
     }
 
     @Test
@@ -170,6 +222,24 @@ class LargeMessageStoringClientTest {
         final byte[] returnBytes = {2};
         when(this.protocol.serialize(new LargeMessagePayload(true, uriBytes), headers, false)).thenReturn(returnBytes);
         assertThat(storer.storeBytes(TOPIC, serialize("foo"), false, headers))
+                .isEqualTo(returnBytes);
+    }
+
+    @Test
+    void shouldWriteBackedTextValueWithoutHeaders() {
+        final String bucket = "bucket";
+        final String basePath = "foo://" + bucket + "/base/";
+        when(this.idGenerator.generateId(serialize("foo"))).thenReturn("key");
+        when(this.client.putObject(serialize("foo"), bucket, "base/" + TOPIC + "/values/key"))
+                .thenReturn("uri");
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(BlobStorageURI.create(basePath))
+                .maxSize(0)
+                .build();
+        final byte[] uriBytes = getUriBytes("uri");
+        final byte[] returnBytes = {2};
+        when(this.protocol.serialize(new LargeMessagePayload(true, uriBytes), false)).thenReturn(returnBytes);
+        assertThat(storer.storeBytes(TOPIC, serialize("foo"), false))
                 .isEqualTo(returnBytes);
     }
 
@@ -205,6 +275,23 @@ class LargeMessageStoringClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void shouldThrowExceptionOnErrorWithoutHeaders(final boolean isKey) {
+        final String bucket = "bucket";
+        final String basePath = "foo://" + bucket + "/base/";
+        when(this.idGenerator.generateId(any())).thenReturn("key");
+        when(this.client.putObject(any(), eq(bucket), any())).thenThrow(UncheckedIOException.class);
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(BlobStorageURI.create(basePath))
+                .maxSize(0)
+                .build();
+        final byte[] foo = serialize("foo");
+        assertThatExceptionOfType(UncheckedIOException.class)
+                .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey));
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void shouldThrowExceptionOnNullTopic(final boolean isKey) {
         final String bucket = "bucket";
         final String basePath = "foo://" + bucket + "/base/";
@@ -222,6 +309,22 @@ class LargeMessageStoringClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void shouldThrowExceptionOnNullTopicWithoutHeaders(final boolean isKey) {
+        final String bucket = "bucket";
+        final String basePath = "foo://" + bucket + "/base/";
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(BlobStorageURI.create(basePath))
+                .maxSize(0)
+                .build();
+        final byte[] foo = serialize("foo");
+        assertThatNullPointerException()
+                .isThrownBy(() -> storer.storeBytes(null, foo, isKey))
+                .withMessage("Topic must not be null");
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void shouldThrowExceptionOnNullBasePath(final boolean isKey) {
         final LargeMessageStoringClient storer = this.createStorer()
                 .basePath(null)
@@ -233,6 +336,20 @@ class LargeMessageStoringClientTest {
                 .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey, headers))
                 .withMessage("Base path must not be null");
         verify(this.protocol, never()).serialize(any(), any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldThrowExceptionOnNullBasePathWithoutHeaders(final boolean isKey) {
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(null)
+                .maxSize(0)
+                .build();
+        final byte[] foo = serialize("foo");
+        assertThatNullPointerException()
+                .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey))
+                .withMessage("Base path must not be null");
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
     }
 
     @ParameterizedTest
@@ -255,12 +372,40 @@ class LargeMessageStoringClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void shouldThrowExceptionOnNullIdGeneratorWithoutHeaders(final boolean isKey) {
+        final String bucket = "bucket";
+        final String basePath = "foo://" + bucket + "/base/";
+        final LargeMessageStoringClient storer = this.createStorer()
+                .basePath(BlobStorageURI.create(basePath))
+                .maxSize(0)
+                .idGenerator(null)
+                .build();
+        final byte[] foo = serialize("foo");
+        assertThatNullPointerException()
+                .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey))
+                .withMessage("Id generator must not be null");
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void shouldWriteNonBackedTextWithConfig(final boolean isKey) {
         final Map<String, Object> properties = ImmutableMap.<String, Object>builder()
                 .put(AbstractLargeMessageConfig.MAX_BYTE_SIZE_CONFIG, Integer.MAX_VALUE)
                 .build();
         final LargeMessageStoringClient storer = createStorer(properties);
         assertThat(storer.storeBytes(null, serialize("foo"), isKey, new RecordHeaders()))
+                .satisfies(backedText -> expectNonBackedText("foo", backedText));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldWriteNonBackedTextWithoutHeadersWithConfig(final boolean isKey) {
+        final Map<String, Object> properties = ImmutableMap.<String, Object>builder()
+                .put(AbstractLargeMessageConfig.MAX_BYTE_SIZE_CONFIG, Integer.MAX_VALUE)
+                .build();
+        final LargeMessageStoringClient storer = createStorer(properties);
+        assertThat(storer.storeBytes(null, serialize("foo"), isKey))
                 .satisfies(backedText -> expectNonBackedText("foo", backedText));
     }
 
@@ -279,6 +424,18 @@ class LargeMessageStoringClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    void shouldWriteNonBackedTextWithoutHeadersWithConfigAndHeaders(final boolean isKey) {
+        final Map<String, Object> properties = ImmutableMap.<String, Object>builder()
+                .put(AbstractLargeMessageConfig.MAX_BYTE_SIZE_CONFIG, Integer.MAX_VALUE)
+                .put(AbstractLargeMessageConfig.USE_HEADERS_CONFIG, true)
+                .build();
+        final LargeMessageStoringClient storer = createStorer(properties);
+        assertThat(storer.storeBytes(null, serialize("foo"), isKey))
+                .satisfies(backedText -> expectNonBackedText("foo", backedText));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     void shouldWriteBackedTextWithConfig(final boolean isKey) {
         final Map<String, Object> properties = ImmutableMap.<String, Object>builder()
                 .put(AbstractLargeMessageConfig.MAX_BYTE_SIZE_CONFIG, 0)
@@ -290,6 +447,20 @@ class LargeMessageStoringClientTest {
                 .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey, headers))
                 .withMessage("Base path must not be null");
         verify(this.protocol, never()).serialize(any(), any(), eq(isKey));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldWriteBackedTextWithoutHeadersWithConfig(final boolean isKey) {
+        final Map<String, Object> properties = ImmutableMap.<String, Object>builder()
+                .put(AbstractLargeMessageConfig.MAX_BYTE_SIZE_CONFIG, 0)
+                .build();
+        final LargeMessageStoringClient storer = createStorer(properties);
+        final byte[] foo = serialize("foo");
+        assertThatNullPointerException()
+                .isThrownBy(() -> storer.storeBytes(TOPIC, foo, isKey))
+                .withMessage("Base path must not be null");
+        verify(this.protocol, never()).serialize(any(), eq(isKey));
     }
 
     private LargeMessageStoringClientBuilder createStorer() {

--- a/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageDeserializer.java
+++ b/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageDeserializer.java
@@ -62,11 +62,7 @@ public class LargeMessageDeserializer<T> implements Deserializer<T> {
         this.isKey = isKey;
     }
 
-    /**
-     * @since 2.2.0
-     * @deprecated Use {@link #deserialize(String, Headers, byte[])}
-     */
-    @Deprecated
+
     @Override
     public T deserialize(final String topic, final byte[] data) {
         Objects.requireNonNull(this.deserializer);

--- a/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageDeserializer.java
+++ b/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageDeserializer.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 
@@ -70,7 +69,10 @@ public class LargeMessageDeserializer<T> implements Deserializer<T> {
     @Deprecated
     @Override
     public T deserialize(final String topic, final byte[] data) {
-        return this.deserialize(topic, new RecordHeaders(), data);
+        Objects.requireNonNull(this.deserializer);
+        Objects.requireNonNull(this.client);
+        final byte[] bytes = this.client.retrieveBytes(data, this.isKey);
+        return this.deserializer.deserialize(topic, bytes);
     }
 
     @Override

--- a/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageSerializer.java
+++ b/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageSerializer.java
@@ -63,11 +63,6 @@ public class LargeMessageSerializer<T> implements Serializer<T> {
         this.isKey = isKey;
     }
 
-    /**
-     * @since 2.2.0
-     * @deprecated Use {@link #serialize(String, Headers, Object)}
-     */
-    @Deprecated
     @Override
     public byte[] serialize(final String topic, final T data) {
         Objects.requireNonNull(this.serializer);

--- a/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageSerializer.java
+++ b/large-message-serde/src/main/java/com/bakdata/kafka/LargeMessageSerializer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019 bakdata
+ * Copyright (c) 2022 bakdata
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ import java.util.Objects;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -71,7 +70,10 @@ public class LargeMessageSerializer<T> implements Serializer<T> {
     @Deprecated
     @Override
     public byte[] serialize(final String topic, final T data) {
-        return this.serialize(topic, new RecordHeaders(), data);
+        Objects.requireNonNull(this.serializer);
+        Objects.requireNonNull(this.client);
+        final byte[] bytes = this.serializer.serialize(topic, data);
+        return this.client.storeBytes(topic, bytes, this.isKey);
     }
 
     @Override

--- a/large-message-serde/src/test/java/com/bakdata/kafka/LargeMessageSerdeTest.java
+++ b/large-message-serde/src/test/java/com/bakdata/kafka/LargeMessageSerdeTest.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 bakdata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.bakdata.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.bakdata.fluent_kafka_streams_tests.TestInput;
+import com.bakdata.fluent_kafka_streams_tests.TestOutput;
+import com.bakdata.fluent_kafka_streams_tests.junit5.TestTopologyExtension;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
+import org.jooq.lambda.Seq;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class LargeMessageSerdeTest {
+
+    @RegisterExtension
+    static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent()
+            .withSecureConnection(false).build();
+    private static final String INPUT_TOPIC_1 = "input1";
+    private static final String INPUT_TOPIC_2 = "input2";
+    private static final String OUTPUT_TOPIC = "output";
+    @RegisterExtension
+    TestTopologyExtension<Integer, String> topology =
+            new TestTopologyExtension<>(LargeMessageSerdeTest::createTopology, createProperties());
+
+    private static Properties createProperties() {
+        final Map<String, Object> endpointConfig = getEndpointConfig();
+        final Properties properties = new Properties();
+        properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "broker");
+        properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "test");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, LargeMessageSerde.class);
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, LargeMessageSerde.class);
+        properties.putAll(endpointConfig);
+        properties.put(LargeMessageSerdeConfig.KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        properties.put(LargeMessageSerdeConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        properties.put(AbstractLargeMessageConfig.USE_HEADERS_CONFIG, true);
+        return properties;
+    }
+
+    private static Map<String, Object> getEndpointConfig() {
+        final Map<String, Object> largeMessageConfig = new HashMap<>();
+        largeMessageConfig.put(AbstractLargeMessageConfig.S3_ENDPOINT_CONFIG,
+                "http://localhost:" + S3_MOCK.getHttpPort());
+        largeMessageConfig.put(AbstractLargeMessageConfig.S3_REGION_CONFIG, "us-east-1");
+        largeMessageConfig.put(AbstractLargeMessageConfig.S3_ACCESS_KEY_CONFIG, "foo");
+        largeMessageConfig.put(AbstractLargeMessageConfig.S3_SECRET_KEY_CONFIG, "bar");
+        largeMessageConfig.put(AbstractLargeMessageConfig.S3_ENABLE_PATH_STYLE_ACCESS_CONFIG, true);
+        return largeMessageConfig;
+    }
+
+    private static Topology createTopology() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<String, String> input1 =
+                builder.stream(INPUT_TOPIC_1, Consumed.with(Serdes.String(), Serdes.String()))
+                        .selectKey((k, v) -> k.substring(0, 1))
+                        .toTable();
+        final KTable<String, String> input2 =
+                builder.stream(INPUT_TOPIC_2, Consumed.with(Serdes.String(), Serdes.String()))
+                        .selectKey((k, v) -> k.substring(0, 1))
+                        .toTable();
+        final KTable<String, String> joined = input1.join(input2, (l, r) -> l + r);
+        joined.toStream()
+                .to(OUTPUT_TOPIC, Produced.with(Serdes.String(), Serdes.String()));
+        return builder.build();
+    }
+
+    @Test
+    void shouldJoin() {
+        // this test creates a topology with a changelog store. The changelog store uses the Serde without headers
+        this.getInput(INPUT_TOPIC_1)
+                .add("a", "foo");
+        this.getInput(INPUT_TOPIC_2)
+                .add("a", "bar");
+        final List<ProducerRecord<String, String>> records = Seq.seq(this.getOutput()).toList();
+        assertThat(records)
+                .hasSize(1)
+                .anySatisfy(record -> {
+                    assertThat(record.key()).isEqualTo("a");
+                    assertThat(record.value()).isEqualTo("foobar");
+                });
+    }
+
+    private TestOutput<String, String> getOutput() {
+        return this.topology.streamOutput()
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String());
+    }
+
+    private TestInput<String, String> getInput(final String topic) {
+        return this.topology.input(topic)
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String());
+    }
+
+}


### PR DESCRIPTION
Changelog topics, e.g. created when joining, do not use headers when (de-)serializing data. Therefore, we need to use the byte flag serialization in these cases