### PR TITLE
Support s3 path style access

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-publish:
     name: Java Gradle
-    uses: bakdata/ci-templates/.github/workflows/java-gradle-library.yaml@1.40.6
+    uses: bakdata/ci-templates/.github/workflows/java-gradle-library.yaml@1.46.3
     with:
       java-version: 17
     secrets:

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -19,5 +19,4 @@ jobs:
       signing-password: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
       ossrh-username: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
       ossrh-password: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
-      github-username: ${{ secrets.GH_USERNAME }}
       github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   java-gradle-release:
     name: Java Gradle
-    uses: bakdata/ci-templates/.github/workflows/java-gradle-release.yaml@1.40.6
+    uses: bakdata/ci-templates/.github/workflows/java-gradle-release.yaml@1.46.3
     with:
       java-version: 17
       release-type: "${{ inputs.release-type }}"

--- a/README.md
+++ b/README.md
@@ -149,13 +149,14 @@ Endpoint to use for connection to Amazon S3. Leave empty if default S3 endpoint 
 
   * Type: string
   * Default: ""
+  * Importance: low
 
  ``large.message.s3.path.style.access``
   Enable path-style access for S3 client.
 
   * Type: boolean
   * Default: false
-  * Importance: low * Importance: low
+  * Importance: low
 
 ``large.message.abs.connection.string``
   Azure connection string for connection to blob storage. Leave empty if Azure credential provider chain should be used.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ for backwards compatibility but leads to increased memory usage. It is recommend
    * Default: ""
    * Importance: low
 
-  
+
  ``large.message.s3.role.external.id``
    AWS STS role external ID used when retrieving session credentials under an assumed role. Leave empty if AWS Basic provider or AWS credential provider chain should be used.
 
@@ -149,7 +149,13 @@ Endpoint to use for connection to Amazon S3. Leave empty if default S3 endpoint 
 
   * Type: string
   * Default: ""
-  * Importance: low
+
+ ``large.message.s3.path.style.access``
+  Enable path-style access for S3 client.
+
+  * Type: boolean
+  * Default: false
+  * Importance: low * Importance: low
 
 ``large.message.abs.connection.string``
   Azure connection string for connection to blob storage. Leave empty if Azure credential provider chain should be used.
@@ -161,7 +167,7 @@ Endpoint to use for connection to Amazon S3. Leave empty if default S3 endpoint 
 ``large.message.gs.key.path``
   Google service account key JSON path. Leave empty If the environment variable GOOGLE_APPLICATION_CREDENTIALS is set
   or if you want to use the default service account provided by your computer engine. For more information about
-  authenticating as a service account please 
+  authenticating as a service account please
   refer to the [main documentation](https://cloud.google.com/docs/authentication/production).
 
   * Type: string

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,13 +36,6 @@ configure<com.bakdata.gradle.SonatypeSettings> {
     }
 }
 
-configure<org.hildan.github.changelog.plugin.GitHubChangelogExtension> {
-    githubUser = "bakdata"
-    githubRepository = "kafka-large-message-serde"
-    futureVersionTag = findProperty("changelog.releaseVersion")?.toString()
-    sinceTag = findProperty("changelog.sinceTag")?.toString()
-}
-
 subprojects {
     apply(plugin = "java-library")
     apply(plugin = "java-test-fixtures")
@@ -52,11 +45,5 @@ subprojects {
         toolchain {
             languageVersion = JavaLanguageVersion.of(11)
         }
-    }
-}
-
-release {
-    git {
-        requireBranch.set("master")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("net.researchgate.release") version "3.0.2"
-    id("com.bakdata.sonar") version "1.1.17"
-    id("com.bakdata.sonatype") version "1.1.14"
-    id("org.hildan.github.changelog") version "2.2.0"
+    id("com.bakdata.release") version "1.4.0"
+    id("com.bakdata.sonar") version "1.4.0"
+    id("com.bakdata.sonatype") version "1.4.0"
     id("io.freefair.lombok") version "8.4"
 }
 

--- a/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
+++ b/large-message-core/src/main/java/com/bakdata/kafka/AbstractLargeMessageConfig.java
@@ -141,6 +141,9 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
     public static final String S3_ENDPOINT_DOC =
             "Endpoint to use for connection to Amazon S3. Leave empty if default S3 endpoint should be used.";
     public static final String S3_ENDPOINT_DEFAULT = "";
+    public static final String S3_ENABLE_PATH_STYLE_ACCESS_CONFIG = S3_PREFIX + "path.style.access";
+    public static final String S3_ENABLE_PATH_STYLE_ACCESS_DOC = "Enable path-style access for S3 client.";
+    public static final boolean S3_ENABLE_PATH_STYLE_ACCESS_DEFAULT = false;
     public static final String S3_REGION_DEFAULT = "";
     public static final String S3_ACCESS_KEY_DOC = "AWS access key to use for connecting to S3. Leave empty if AWS"
             + " credential provider chain or STS Assume Role provider should be used.";
@@ -207,6 +210,8 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
                         COMPRESSION_TYPE_DOC)
                 // Amazon S3
                 .define(S3_ENDPOINT_CONFIG, Type.STRING, S3_ENDPOINT_DEFAULT, Importance.LOW, S3_ENDPOINT_DOC)
+                .define(S3_ENABLE_PATH_STYLE_ACCESS_CONFIG, Type.BOOLEAN, S3_ENABLE_PATH_STYLE_ACCESS_DEFAULT,
+                        Importance.LOW, S3_ENABLE_PATH_STYLE_ACCESS_DOC)
                 .define(S3_REGION_CONFIG, Type.STRING, S3_REGION_DEFAULT, Importance.LOW, S3_REGION_DOC)
                 .define(S3_ACCESS_KEY_CONFIG, Type.PASSWORD, S3_ACCESS_KEY_DEFAULT, Importance.LOW, S3_ACCESS_KEY_DOC)
                 .define(S3_SECRET_KEY_CONFIG, Type.PASSWORD, S3_SECRET_KEY_DEFAULT, Importance.LOW, S3_SECRET_KEY_DOC)
@@ -296,12 +301,19 @@ public class AbstractLargeMessageConfig extends AbstractConfig {
         this.getAmazonEndpointOverride().ifPresent(clientBuilder::endpointOverride);
         this.getAmazonRegion().ifPresent(clientBuilder::region);
         this.getAmazonCredentialsProvider().ifPresent(clientBuilder::credentialsProvider);
+        if (this.enableAmazonS3PathStyleAccess()) {
+            clientBuilder.forcePathStyle(true);
+        }
         return new AmazonS3Client(clientBuilder.build());
     }
 
     private Optional<URI> getAmazonEndpointOverride() {
         final String endpoint = this.getString(S3_ENDPOINT_CONFIG);
         return isEmpty(endpoint) ? Optional.empty() : Optional.of(URI.create(endpoint));
+    }
+
+    private boolean enableAmazonS3PathStyleAccess() {
+        return this.getBoolean(S3_ENABLE_PATH_STYLE_ACCESS_CONFIG);
     }
 
     private Optional<Region> getAmazonRegion() {


### PR DESCRIPTION
Path style access was removed in #40 but we require it when using other s3 compatible products as object store.